### PR TITLE
Correcting a typo (?) for libs in linux

### DIFF
--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -47,7 +47,7 @@ close(so)
 end
 
 @linux_only begin
-  path = match(Regex("lopencv"), output)
+  path = match(Regex("libopencv"), output)
   for i in opencv_libraries
       if match(Regex("$(i[11:end-6])"), output) == nothing
           println("$(i) is not found in pkg-config")


### PR DESCRIPTION
At least in Ubuntu 14.04.
I was getting the ``ERROR: LoadError: No pre-installed libraries. Set path manually or install OpenCV.``  before that.

After this correction, I'm still getting the following error though: 
```julia
ERROR: LoadError: UndefVarError: RTLD_GLOBAL not defined
 in anonymous at ./no file:76
 in include at ./boot.jl:250
 in include_from_node1 at ./loading.jl:129
 in reload_path at ./loading.jl:153
 in _require at ./loading.jl:68
 in require at ./loading.jl:52
while loading ~/.julia/v0.4/OpenCV/src/OpenCV.jl, in expression starting on line 71
```