### PR TITLE
Correction for Linux operating system

### DIFF
--- a/deps/Qt_support.jl
+++ b/deps/Qt_support.jl
@@ -20,13 +20,14 @@ end
 @linux_only begin
     const qtincdir = "/usr/include/qt5"
     const qtlibdir = "/usr/lib/x86_64-linux-gnu/"
+    const QtWidgets = joinpath(qtincdir,"QtWidgets")
 
     addHeaderDir(qtincdir, kind = C_System)
     addHeaderDir(QtWidgets, kind = C_System)
 
-    dlopen(joinpath(qtlibdir,"libQt5Core.so"), RTLD_GLOBAL)
-    dlopen(joinpath(qtlibdir,"libQt5Gui.so"), RTLD_GLOBAL)
-    dlopen(joinpath(qtlibdir,"libQt5Widgets.so"), RTLD_GLOBAL)
+    Libdl.dlopen(joinpath(qtlibdir,"libQt5Core.so"), Libdl.RTLD_GLOBAL)
+    Libdl.dlopen(joinpath(qtlibdir,"libQt5Gui.so"), Libdl.RTLD_GLOBAL)
+    Libdl.dlopen(joinpath(qtlibdir,"libQt5Widgets.so"), Libdl.RTLD_GLOBAL)
 end
 
 cxxinclude("QApplication", isAngled=true)

--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -64,7 +64,7 @@ else  # Load libs/headers from OpenCV/deps/usr/lib/ - only compatible with OSX
     const cvheaderdir = @osx? joinpath(Pkg.dir("OpenCV"), "./deps/usr/include/") : throw(ErrorException("No pre-installed headers. Set path manually or install OpenCV."))
 end
 
-addHeaderDir(cvlibdir; kind = C_System)
+addHeaderDir(cvheaderdir, kind = C_System)
 
 # Load OpenCV shared libraries (default file extension is .dylib)
 # IMPORTANT: make sure to link symbols accross libraries with RTLD_GLOBAL
@@ -73,7 +73,7 @@ for i in opencv_libraries
     @linux_only begin
          i = swapext(i[1:end-6], ".so")
     end
-    dlopen_e(joinpath(cvlibdir,i), RTLD_GLOBAL)==C_NULL ? println("Not loading $(i)"): nothing
+    Libdl.dlopen_e(joinpath(cvlibdir,i), Libdl.RTLD_GLOBAL)==C_NULL ? println("Not loading $(i)"): nothing
 end
 
 # Now include C++ header files


### PR DESCRIPTION
Corrected addheaderpath input in OpenCV.jl, changed dlopen_e to Libdl.dlopen_e, defined QtWidgets in deps/Qt_support.jll