### PR TITLE
Fix path regex for Ubuntu 14.04

### DIFF
--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -47,7 +47,7 @@ close(so)
 end
 
 @linux_only begin
-  path = match(Regex("libopencv"), output)
+  path = match(Regex("libopencv|lopencv"), output)
   for i in opencv_libraries
       if match(Regex("$(i[11:end-6])"), output) == nothing
           println("$(i) is not found in pkg-config")


### PR DESCRIPTION
OpenCV library names output by `pkg-config --libs opencv` have prefix lopencv on Ubuntu 14.04.  I have accomodated the same in the regular expression.