### PR TITLE
rectifying index in img to mat conversion

### DIFF
--- a/src/OpenCV_ImagesSupport.jl
+++ b/src/OpenCV_ImagesSupport.jl
@@ -26,7 +26,7 @@ function convertToMat(image)
         for j = 1:Base.size(img,2)     # index row first (Mat is row-major order)
             for k =1:Base.size(img,1)  # index column second
                 # slow algorithm  - will try to use pointer method (C++)!
-                pixset(mat, k, j, float(img[k,j,1].i))
+                pixset(mat, k-1, j-1, float(img[k,j,1].i))
             end
         end
     end


### PR DESCRIPTION
I suppose alike what we have done for image conversion in case of grayscale and binary (cd<3), for coloured images also:
"# -1 to have 0-indexing per C++"

" " "if (cd < 3)   # grayscale or binary
        for j = 1:Base.size(img,2)     # index row first (Mat is row-major order)
            for k =1:Base.size(img,1)  # index column second
                # slow algorithm  - will try to use pointer method (C++)!
                pixset(mat, k-1, j-1, float(img[k,j,1].i))
            end
        end
    end
" " "
Although I haven't run this yet since I was looking through the code from another pc. May be I am misinterpreting the situation.

Thank you.